### PR TITLE
Added support for app projects created with the Iron scaffolding tool

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,6 +11,10 @@ set -e
 BUILDPACK_DIR=$(cd -P -- "$(dirname -- "$0")" && cd .. && pwd -P)
 # Get the directory our app is checked out in (the "BUILD_DIR"), passed by Heroku
 APP_CHECKOUT_DIR=$1
+# The Iron scaffolding tool (https://github.com/iron-meteor/iron-cli) place the
+# Meteor app in /app/ instead of in the root. So let's try the /app/ folder if
+# there is no Meteor app in the root.
+[ ! -d "$APP_CHECKOUT_DIR/.meteor" ] && APP_CHECKOUT_DIR="$APP_CHECKOUT_DIR/app"
 # Where we will install meteor. Has to be outside the APP_CHECKOUT_DIR.
 METEOR_DIR=`mktemp -d "$BUILDPACK_DIR"/meteor-XXXX`
 # Where we'll put things we compile.
@@ -86,5 +90,5 @@ EOF
 # binary dependencies, phantomjs for spiderable, etc.
 echo "-----> Running extras"
 for file in `ls "$BUILDPACK_DIR"/extra | sort`; do
-    . "$BUILDPACK_DIR"/extra/$file 
+    . "$BUILDPACK_DIR"/extra/$file
 done

--- a/bin/release
+++ b/bin/release
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# Default dir
+DIR=".meteor"
+
+# The Iron scaffolding tool (https://github.com/iron-meteor/iron-cli) place the
+# Meteor app in /app/ instead of in the root. So let's try the /app/ folder if
+# there is no Meteor app in the root.
+[ ! -d "$DIR" ] && DIR="app/$DIR"
+
 cat <<EOF
 addons:
   - mongolab

--- a/bin/release
+++ b/bin/release
@@ -12,5 +12,5 @@ cat <<EOF
 addons:
   - mongolab
 default_process_types:
-  web: .meteor/heroku_build/bin/node .meteor/heroku_build/app/main.js
+  web: $DIR/heroku_build/bin/node $DIR/heroku_build/app/main.js
 EOF


### PR DESCRIPTION
The Iron scaffolding tool place the Meteor app in /app/ instead of in the root, so I've added so Horse try /app/ if a Meteor app can't be found in the root.