### PR TITLE
Fix mobile hot code push

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -71,12 +71,6 @@ cd $APP_CHECKOUT_DIR
 # Now on to bundling. Don't put the bundle in $APP_CHECKOUT_DIR, or it will
 # recurse, trying to bundle up its own bundling.
 BUNDLE_DEST=`mktemp -d "$BUILDPACK_DIR/build-XXXX"`
-# <hack issue='https://github.com/meteor/meteor/issues/2867'>
-# Temporary hack to address meteor failing to bundle if mobile targets are
-# included but server URL is not (issue #2).  Remove mobile targets. This
-# should be no-op for any builds that don't have mobile targets.
-HOME=$METEOR_DIR $METEOR remove-platform ios android
-# </hack>
 
 # <hack issue="https://github.com/meteor/meteor/issues/2796>
 # the root cause seems to be related to https://github.com/meteor/meteor/issues/2606
@@ -85,11 +79,12 @@ HOME=$METEOR_DIR $METEOR remove-platform ios android
 # of glibc (contained in cedar-14)
 if [ -n "${BUILDPACK_PRELAUNCH_METEOR+1}" ]; then 
 echo "-----> Pre-launching Meteor to create packages assets and prevent bundling from failing"
-    HOME=$METEOR_DIR timeout -s9 60 $METEOR --settings settings.json || true
+    HOME=$METEOR_DIR timeout -s9 60 $METEOR --settings settings.json --server $ROOT_URL || true
 fi
 # </hack>
 
-HOME=$METEOR_DIR $METEOR build --directory $BUNDLE_DEST
+echo "-----> Building Meteor with ROOT_URL: $ROOT_URL"
+HOME=$METEOR_DIR $METEOR build --server $ROOT_URL --directory $BUNDLE_DEST
 mv $BUNDLE_DEST/bundle "$COMPILE_DIR/app"
 rmdir $BUNDLE_DEST
 


### PR DESCRIPTION
A while back the android and ios platforms were removed to fix #2. But that causes it to not generate `/__cordova/manifest.json` and so hot code push for mobile apps doesn't work.

It looks like meteor has been updated so that removing the platforms is no longer necessary, I added them back and added the --server command-line parameter (this is basically copied from @Alveoli [here](https://github.com/Alveoli/meteor-buildpack-horse/commit/22c99f31baba15ff77f90958959a6b452d8c487c) but without the unrelated README change.

This seems to fix hot code push.