### PR TITLE
Fix failing build w/ android platform and broken mobile HCP

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -76,6 +76,13 @@ cd $APP_SOURCE_DIR
 # recurse, trying to bundle up its own bundling.
 BUNDLE_DEST=`mktemp -d "$BUILDPACK_DIR/build-XXXX"`
 
+# Remove the Android platform because it fails due to the Android tools not
+# being installed, but leave the iOS platform because it's ignored.
+# If we remove both platforms the mobile hot code push will not work.
+# TODO: this means mobile HCP is broken for android-only apps, we need a
+# better solution
+HOME=$METEOR_DIR $METEOR remove-platform android
+
 # <hack issue="https://github.com/meteor/meteor/issues/2796>
 # the root cause seems to be related to https://github.com/meteor/meteor/issues/2606
 # Also remember to use 'heroku stack:set cedar-14' to allow certain recompiled
@@ -83,7 +90,6 @@ BUNDLE_DEST=`mktemp -d "$BUILDPACK_DIR/build-XXXX"`
 # of glibc (contained in cedar-14)
 if [ -n "${BUILDPACK_PRELAUNCH_METEOR+1}" ]; then
 echo "-----> Pre-launching Meteor to create packages assets and prevent bundling from failing"
-    HOME=$METEOR_DIR $METEOR remove-platform ios android
     HOME=$METEOR_DIR timeout -s9 60 $METEOR --settings settings.json || true
 fi
 # </hack>

--- a/bin/compile
+++ b/bin/compile
@@ -81,7 +81,7 @@ BUNDLE_DEST=`mktemp -d "$BUILDPACK_DIR/build-XXXX"`
 # If we remove both platforms the mobile hot code push will not work.
 # TODO: this means mobile HCP is broken for android-only apps, we need a
 # better solution
-HOME=$METEOR_DIR $METEOR remove-platform android
+HOME=$METEOR_DIR $METEOR remove-platform android || true
 
 # <hack issue="https://github.com/meteor/meteor/issues/2796>
 # the root cause seems to be related to https://github.com/meteor/meteor/issues/2606


### PR DESCRIPTION
This fixes this buildpack for apps that have the android platform installed. It also fixes hot code push for all mobile apps that have `BUILDPACK_PRELAUNCH_METEOR` set.

What this does:

- Remove the Android platform because it fails due to the Android tools not being installed
- Leave iOS, even when `BUILDPACK_PRELAUNCH_METEOR` is set, because otherwise mobile hot code push doesn't work (`/__cordova/manifest.json` is not generated if there are no mobile platforms)
- NOTE that this means HCP is broken for android-only apps! I can't think of a solution for that.
