### PR TITLE
Fix correct Meteor upgrade release

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -73,7 +73,7 @@ CUR_RELEASE=`HOME=$METEOR_DIR $METEOR --version | sed -e 's/Meteor /METEOR@/'`
 APP_RELEASE=`cat "$APP_SOURCE_DIR/.meteor/release"`
 if test "$CUR_RELEASE" != "$APP_RELEASE" ; then
   echo "-----> Upgrading meteor to $APP_RELEASE"
-  HOME=$METEOR_DIR $METEOR update --release `cat "$APP_CHECKOUT_DIR/.meteor/release"`
+  HOME=$METEOR_DIR $METEOR update --release $APP_RELEASE
 fi
 
 #


### PR DESCRIPTION
Was getting error this error and this fixes issue.

```
...
remote: Now you need to do one of the following:
remote: 
remote:   (1) Add "$HOME/.meteor" to your path, or
remote:   (2) Run this command as root:
remote:         cp "/tmp/buildpack20160323-159-zawy6e/meteor-S8ze/.meteor/packages/meteor-tool/1.1.10/mt-os.linux.x86_64/scripts/admin/launch-meteor" /usr/bin/meteor
remote: 
remote: Then to get started, take a look at 'meteor --help' or see the docs at
remote: docs.meteor.com.
remote: -----> Upgrading meteor to METEOR@1.3-rc.9
remote: cat: /tmp/build_12c4586cbddaa6f7eb2361c3293338d1/.meteor/release: No such file or directory
remote: The --release option needs a value. Try 'meteor help' for help.
remote: 
remote:  !     Push rejected, failed to compile Node.js app
...
```

