### PR TITLE
Remove phantomjs extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ build.
 Extras included in this branch:
  - `mongo_url.sh`: If `MONGO_URL` is empty, set it to the value of `MONGODB_URI`, `MONGOLAB_URI`, or `MONGOHQ_URL` (in order).
  - `root_url.sh`: If `ROOT_URL` is empty and `HEROKU_APP_NAME` is available, set `ROOT_URL` to `https://$HEROKU_APP_NAME.herokuapp.com`
- - `phantomjs.sh`: Include phantomjs for use with `spiderable`.
 
 ## Where things go
 

--- a/bin/compile
+++ b/bin/compile
@@ -187,8 +187,7 @@ EOF
 #
 
 # source scripts in 'extra' dir, if any.  Create them for custom stuff like
-# binary dependencies, phantomjs for spiderable, additional environment
-# settings, etc.
+# binary dependencies, additional environment settings, etc.
 echo "-----> Running extras"
 for file in `ls "$BUILDPACK_DIR"/extra | sort`; do
   . "$BUILDPACK_DIR"/extra/$file

--- a/extra/phantomjs.sh
+++ b/extra/phantomjs.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-VERSION=1.9.7
-PHANTOM_URL="https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$VERSION-linux-x86_64.tar.bz2"
-
-echo "-----> Installing phantomjs."
-# Just extract the one file (the binary) and not all the examples/readme's/etc.
-FILE="phantomjs-$VERSION-linux-x86_64/bin/phantomjs"
-curl -L -sS $PHANTOM_URL -o - | tar -jxf - -C $COMPILE_DIR $FILE --strip 1


### PR DESCRIPTION
Remove phantomjs due to unreliability of bitbucket servers that host it, and its decreasing relevance as search engines execute javascript.

The original phantomjs extra can still be found in the [phantomjs branch](https://github.com/AdmitHub/meteor-buildpack-horse/tree/phantomjs).