### PR TITLE
Provide ability to build with debug flag

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -161,7 +161,7 @@ fi
 # recurse, trying to bundle up its own bundling.
 BUNDLE_DEST=`mktemp -d "$BUILDPACK_DIR/build-XXXX"`
 echo "-----> Building Meteor with ROOT_URL: $ROOT_URL"
-HOME=$METEOR_DIR $METEOR build --server $ROOT_URL $SERVER_ONLY_FLAG --directory $BUNDLE_DEST
+HOME=$METEOR_DIR $METEOR build $DEBUG_FLAG --server $ROOT_URL $SERVER_ONLY_FLAG --directory $BUNDLE_DEST
 mv $BUNDLE_DEST/bundle "$COMPILE_DIR/app"
 rmdir $BUNDLE_DEST
 


### PR DESCRIPTION
The way I did it is super trivial, you may want to add some checks to it, or maybe just rename it to `$BUILD_OPTIONS`, but the gist is being able to add a flag to a heroku app and have it build the meteor app with debug options.