### PR TITLE
Use "--production" flag with npm install to avoid dev dependencies.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -144,6 +144,7 @@ fi
 
 # If we use npm on root, run npm install.
 if [ -e "$APP_SOURCE_DIR"/package.json ]; then
+  npm config set production
   npm install
 fi
 
@@ -169,7 +170,9 @@ rmdir $BUNDLE_DEST
 
 # If we use npm, run npm install.
 if [ -e "$COMPILE_DIR"/app/programs/server/package.json ]; then
-  cd "$COMPILE_DIR"/app/programs/server && npm install
+  cd "$COMPILE_DIR"/app/programs/server
+  npm config set production
+  npm install
 fi
 
 #

--- a/bin/compile
+++ b/bin/compile
@@ -144,8 +144,7 @@ fi
 
 # If we use npm on root, run npm install.
 if [ -e "$APP_SOURCE_DIR"/package.json ]; then
-  npm config set production
-  npm install
+  npm install --production
 fi
 
 # Related to https://github.com/meteor/meteor/issues/2796 and 
@@ -171,8 +170,7 @@ rmdir $BUNDLE_DEST
 # If we use npm, run npm install.
 if [ -e "$COMPILE_DIR"/app/programs/server/package.json ]; then
   cd "$COMPILE_DIR"/app/programs/server
-  npm config set production
-  npm install
+  npm install --production
 fi
 
 #

--- a/bin/compile
+++ b/bin/compile
@@ -63,8 +63,10 @@ METEOR_DIR=`mktemp -d "$BUILDPACK_DIR"/meteor-XXXX`
 # Where we'll put things we compile.
 COMPILE_DIR_SUFFIX=".meteor/heroku_build"
 COMPILE_DIR="$APP_CHECKOUT_DIR"/"$COMPILE_DIR_SUFFIX"
-# Try to minimize meteor's printing
-METEOR_PRETTY_OUTPUT=0
+# Try to minimize meteor's printing, unless we're running verbosely.
+if [ -z "$BUILDPCK_VERBOSE" ]; then
+  METEOR_PRETTY_OUTPUT=0
+fi
 
 # Create directories as needed.
 mkdir -p "$APP_CHECKOUT_DIR" "$METEOR_DIR" "$COMPILE_DIR"

--- a/bin/compile
+++ b/bin/compile
@@ -64,7 +64,7 @@ METEOR_DIR=`mktemp -d "$BUILDPACK_DIR"/meteor-XXXX`
 COMPILE_DIR_SUFFIX=".meteor/heroku_build"
 COMPILE_DIR="$APP_CHECKOUT_DIR"/"$COMPILE_DIR_SUFFIX"
 # Try to minimize meteor's printing, unless we're running verbosely.
-if [ -z "$BUILDPCK_VERBOSE" ]; then
+if [ -z "$BUILDPACK_VERBOSE" ]; then
   METEOR_PRETTY_OUTPUT=0
 fi
 


### PR DESCRIPTION
Also, only suppress meteor's pretty printing when BUILDPACK_VERBOSE is empty.