### PR TITLE
support scoped npm packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Changes from AdmitHub/meteor-buildpack-horse:
+
+Set `METEOR_BUILD_REINSTALL_NPM` to `true` if you want to reinstall `npm` before attempting to build your Meteor application. This will allow Meteor to use scoped packages. [See here for more info](https://github.com/meteor/meteor/issues/4985).
+
 # Meteor Buildpack Horse
 
 [![Horse](https://i.imgur.com/YhIL9zM.jpg)](https://commons.wikimedia.org/wiki/File:Draw-Costa_Rican-2smallest.jpg)
@@ -12,7 +16,7 @@ To use this with your meteor app and heroku:
         heroku buildpacks:set https://github.com/AdmitHub/meteor-buildpack-horse.git
 
 3. Add the MongoLab addon:
-        
+
         heroku addons:create mongolab
 
 4. Set the `ROOT_URL` environment variable. This is required for bundling and running the app.  Either define it explicitly, or enable the [Dyno Metadata](https://devcenter.heroku.com/articles/dyno-metadata) labs addon to default to `https://<appname>.herokuapp.com`.
@@ -37,7 +41,7 @@ The following are some important environment variables for bundling and running 
 
 The basic buildpack should function correctly for any normal-ish meteor app,
 with or without npm-container.  For extra steps needed for your particular build,
-just add shell scripts to the `extra` folder and they will get sourced into the 
+just add shell scripts to the `extra` folder and they will get sourced into the
 build.
 
 Extras included in this branch:

--- a/bin/compile
+++ b/bin/compile
@@ -142,13 +142,24 @@ if [ -z "$SERVER_ONLY_FLAG" ]; then
   echo "-----> Moving on."
 fi
 
+# Reinstall npm to support scoped packages (see: https://github.com/meteor/meteor/issues/4985)
+if [ -n "$METEOR_BUILD_REINSTALL_NPM" ]; then
+  echo "-----> Upgrading npm version in all meteor-tool versions."
+  METEOR_TOOL_DIR=$METEOR_DIR/.meteor/packages/meteor-tool
+  for meteor_tool_version_dir in $METEOR_TOOL_DIR/*; do
+    cd $meteor_tool_version_dir/mt-*/dev_bundle/lib
+    ../bin/npm install npm
+  done
+  cd $APP_SOURCE_DIR
+fi
+
 # If we use npm on root, run npm install.  Don't use `--production` here, as we
 # may need devDependencies (e.g. webpack) in order to build the meteor app.
 if [ -e "$APP_SOURCE_DIR"/package.json ]; then
   npm install
 fi
 
-# Related to https://github.com/meteor/meteor/issues/2796 and 
+# Related to https://github.com/meteor/meteor/issues/2796 and
 # https://github.com/meteor/meteor/issues/2606.  Some packages only build their
 # assets at runtime, and thus they are not available for bundling unless meteor
 # has been launched.  To opt-in to this, set BUILDPACK_PRELAUNCH_METEOR=1.


### PR DESCRIPTION
In order to support packages that depend on scoped `npm` packages, we have to upgrade the version of `npm` that exists alongside meteor-tool (see: https://github.com/meteor/meteor/issues/4985). This can be configured with an environment variable (`METEOR_BUILD_REINSTALL_NPM`), which defaults to false.