### PR TITLE
Update node version to 4 as this is required by meteor 1.4

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -91,7 +91,7 @@ fi
 # Install node
 #
 echo "-----> Installing node"
-NODE_VERSION=`curl -sS --get https://semver.io/node/resolve/0.10.x`
+NODE_VERSION=`curl -sS --get https://semver.io/node/resolve/4.4.x`
 NODE_URL="http://s3pository.heroku.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz"
 curl -sS $NODE_URL -o - | tar -zxf - -C $COMPILE_DIR --strip 1
 # Export some environment variables for npm to use when compiling stuff.


### PR DESCRIPTION
Probably a better solution would be to implement a more flexible definition of the node version based on the meteor installation but in case anyone wants to quickly get going this tiny change has been verified with a meteor 1.4 app.