### PR TITLE
Support for Meteor 1.4, faster compilation, caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The following are some important environment variables for bundling and running 
  - `METEOR_APP_DIR`: The relative path to the root of your meteor app within your git repository (i.e. the path to the directory that contains `.meteor/`). The buildpack will look in the root of your repository and `app/` subdirectory; if you put your app anywhere else (like `src/`), define this variable to tell the buildpack where to look.
  - `BUILDPACK_PRELAUNCH_METEOR`: If your app uses packages that need to compile their assets on first run, you may need meteor to launch prior to bundling.  If this applies for you, define `BUILDPACK_PRELAUNCH_METEOR=1`. [Reference issue](https://github.com/meteor/meteor/issues/2606).
  - `BUILDPACK_VERBOSE`: Set `BUILDPACK_VERBOSE=1` to enable verbose bash debugging during slug compilation. Only takes effect after the environment variables have been loaded.
+ - `BUILDPACK_CLEAR_CACHE`: This buildpack stores the meteor installation in the [CACHE_DIR](https://devcenter.heroku.com/articles/buildpack-api#caching) to speed up subsequent builds. Set `BUILDPACK_CLEAR_CACHE=1` to clear this cache on startup.
+ - `BUILD_OPTIONS`: Set to any additional options you'd like to add to the invocation of `meteor build`, for example `--debug` or `--allow-incompatible-update`.
 
 ## Extras
 

--- a/bin/compile
+++ b/bin/compile
@@ -133,6 +133,7 @@ METEOR_NODE=`find $METEOR_DIR -wholename "*$APP_RELEASE*/dev_bundle/bin/node"`
 METEOR_NPM=`echo "$METEOR_NPM" | sed -e 's/[[:space:]]*$//'`
 METEOR_NODE=`echo "$METEOR_NODE" | sed -e 's/[[:space:]]*$//'`
 if [ -z "$METEOR_NPM" ] || [ -z "$METEOR_NODE" ] ; then
+  ls -R "$METEOR_DIR"
   echo "FATAL: Can't find npm/node within meteor bundle. This is a bug. Please open an issue at https://github.com/AdmitHub/meteor-buildpack-horse.";
   exit 1
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -127,8 +127,8 @@ fi
 # Instead, search for the binaries within meteor, and copy them into our built
 # slug.
 
-METEOR_NPM=`find $METEOR_DIR -wholename "*$APP_RELEASE*/dev_bundle/bin/npm"`
-METEOR_NODE=`find $METEOR_DIR -wholename "*$APP_RELEASE*/dev_bundle/bin/node"`
+METEOR_NPM=`find $METEOR_DIR -wholename "*/dev_bundle/bin/npm"`
+METEOR_NODE=`find $METEOR_DIR -wholename "*/dev_bundle/bin/node"`
 # Trim whitespace
 METEOR_NPM=`echo "$METEOR_NPM" | sed -e 's/[[:space:]]*$//'`
 METEOR_NODE=`echo "$METEOR_NODE" | sed -e 's/[[:space:]]*$//'`

--- a/bin/compile
+++ b/bin/compile
@@ -60,7 +60,6 @@ fi
 
 # Where we will install meteor. Has to be outside the APP_CHECKOUT_DIR.
 METEOR_DIR=`mktemp -d "$BUILDPACK_DIR"/meteor-XXXX`
-HOME=$METEOR_DIR
 # Where we'll put things we compile.
 COMPILE_DIR_SUFFIX=".meteor/heroku_build"
 COMPILE_DIR="$APP_CHECKOUT_DIR"/"$COMPILE_DIR_SUFFIX"
@@ -92,18 +91,18 @@ fi
 # Install meteor
 #
 echo "-----> Installing meteor"
-curl -sS https://install.meteor.com | /bin/sh
+curl -sS https://install.meteor.com | HOME="$METEOR_DIR" /bin/sh
 METEOR="$METEOR_DIR/.meteor/meteor" # The meteor binary.
 
 # Maybe update release. Upgrade only if needed because it's slow.
-CUR_RELEASE=`$METEOR --version | sed -e 's/Meteor /METEOR@/'`
+CUR_RELEASE=`HOME=$METEOR_DIR $METEOR --version | sed -e 's/Meteor /METEOR@/'`
 APP_RELEASE=`cat "$APP_SOURCE_DIR/.meteor/release"`
 if test "$CUR_RELEASE" != "$APP_RELEASE" ; then
   # Sort CUR_RELEASE and APP_RELEASE and find the oldest
   OLDER_RELEASE=`echo "$CUR_RELEASE\n$APP_RELEASE" | sort --version-sort | head -n1`
   if [ "$CUR_RELEASE" = "$OLDER_RELEASE" ]; then
     echo "-----> Upgrading meteor to $APP_RELEASE"
-    $METEOR update --release $APP_RELEASE
+    HOME=$METEOR_DIR $METEOR update --release $APP_RELEASE
   fi
 fi
 
@@ -116,7 +115,7 @@ cd $APP_SOURCE_DIR
 # Determine if we have --server-only flag capability. Allow non-zero return from grep.
 echo "-----> Checking if this meteor version supports --server-only"
 set +e
-HAS_SERVER_ONLY=`$METEOR help build | grep -e '--server-only'`
+HAS_SERVER_ONLY=`HOME=$METEOR_DIR $METEOR help build | grep -e '--server-only'`
 set -e
 if [ -n "$HAS_SERVER_ONLY" ] ; then
   SERVER_ONLY_FLAG='--server-only'
@@ -127,14 +126,14 @@ fi
 # platform gets ignored properly.
 if [ -z "$SERVER_ONLY_FLAG" ]; then
   echo "-----> Attempting to remove android platform."
-  $METEOR remove-platform android || true
+  HOME=$METEOR_DIR $METEOR remove-platform android || true
   echo "-----> Moving on."
 fi
 
 # If we use npm on root, run npm install.  Don't use `--production` here, as we
 # may need devDependencies (e.g. webpack) in order to build the meteor app.
 if [ -e "$APP_SOURCE_DIR"/package.json ]; then
-  $METEOR npm install
+  HOME=$METEOR_DIR $METEOR npm install
 fi
 
 # Related to https://github.com/meteor/meteor/issues/2796 and 
@@ -145,23 +144,26 @@ if [ -n "${BUILDPACK_PRELAUNCH_METEOR+1}" ]; then
   echo "-----> BUILDPACK_PRELAUNCH_METEOR: Pre-launching meteor to build packages assets"
   # Remove the Android platform because it fails due to the Android tools not
   # being installed, but leave the iOS platform because it's ignored.
-  $METEOR remove-platform android || true
-  timeout -s9 60 $METEOR --settings settings.json || true
+  HOME=$METEOR_DIR $METEOR remove-platform android || true
+  HOME=$METEOR_DIR timeout -s9 60 $METEOR --settings settings.json || true
 fi
 
 # Now on to bundling. Don't put the bundle in $APP_CHECKOUT_DIR, or it will
 # recurse, trying to bundle up its own bundling.
 BUNDLE_DEST=`mktemp -d "$BUILDPACK_DIR/build-XXXX"`
 echo "-----> Building Meteor with ROOT_URL: $ROOT_URL"
-$METEOR build --server $ROOT_URL $SERVER_ONLY_FLAG --directory $BUNDLE_DEST
+HOME=$METEOR_DIR $METEOR build --server $ROOT_URL $SERVER_ONLY_FLAG --directory $BUNDLE_DEST
 mv $BUNDLE_DEST/bundle "$COMPILE_DIR/app"
 rmdir $BUNDLE_DEST
 
 # Run npm install on the built slug; only for `--production` dependencies.
 if [ -e "$COMPILE_DIR"/app/programs/server/package.json ]; then
   cd "$COMPILE_DIR"/app/programs/server
-  $METEOR npm install --production
+  HOME=$METEOR_DIR $METEOR npm install --production
 fi
+
+# Move meteor installation to where we can use it.
+mv "$METEOR_DIR" "$APP_CHECKOUT_DIR/meteor-dist"
 
 #
 # Environment
@@ -171,7 +173,6 @@ echo "-----> Adding PATH environment"
 mkdir -p "$APP_CHECKOUT_DIR"/.profile.d
 cat > "$APP_CHECKOUT_DIR"/.profile.d/path.sh <<EOF
   #!/bin/sh
-  export HOME=$HOME
   export PATH=$METEOR_DIR/.meteor:\$HOME/$COMPILE_DIR_SUFFIX/bin:\$PATH
   export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:\$HOME/$COMPILE_DIR_SUFFIX/lib
 EOF

--- a/bin/compile
+++ b/bin/compile
@@ -91,7 +91,7 @@ fi
 # Install meteor
 #
 echo "-----> Installing meteor"
-APP_RELEASE=`cat "$APP_SOURCE_DIR/.meteor/release"` | sed -e 's/METEOR@//'
+APP_RELEASE=`cat "$APP_SOURCE_DIR/.meteor/release" | sed -e 's/METEOR@//'`
 curl -sS "https://install.meteor.com/?release=$APP_RELEASE" | HOME="$METEOR_DIR" /bin/sh
 METEOR="$METEOR_DIR/.meteor/meteor" # The meteor binary.
 

--- a/bin/compile
+++ b/bin/compile
@@ -69,7 +69,7 @@ if [ -z "$BUILDPACK_VERBOSE" ]; then
 fi
 
 # Create directories as needed.
-mkdir -p "$APP_CHECKOUT_DIR" "$METEOR_DIR" "$COMPILE_DIR"
+mkdir -p "$APP_CHECKOUT_DIR" "$METEOR_DIR" "$COMPILE_DIR" "$COMPILE_DIR/bin"
 
 # Update the path a place to store our compiled app/binaries
 PATH="$METEOR_DIR/.meteor:$COMPILE_DIR/bin:$PATH"

--- a/bin/compile
+++ b/bin/compile
@@ -60,7 +60,7 @@ if [ ! -d "$APP_SOURCE_DIR/.meteor" ] && [ -d "$APP_SOURCE_DIR/app/.meteor" ]; t
   APP_SOURCE_DIR="$APP_SOURCE_DIR/app/"
 fi
 if [ ! -d "$APP_SOURCE_DIR/.meteor" ]; then
-  echo "FATAL: Can't find meteor app. Set METEOR_APP_DIR to the relative location of the meteor app within your repository if it's not in the root or 'app/' supdirectory.  (Tried ${APP_SOURCE_DIR})"
+  echo "FATAL: Can't find meteor app. Set METEOR_APP_DIR to the relative location of the meteor app within your repository if it's not in the root or 'app/' subdirectory.  (Tried ${APP_SOURCE_DIR})"
   exit 1
 fi
 
@@ -176,7 +176,7 @@ fi
 # Now on to bundling. Don't put the bundle in $APP_CHECKOUT_DIR during
 # bundling, or it will recurse, trying to bundle up its own bundling.
 
-echo "-----> Building Meteor with ROOT_URL: $ROOT_URL"
+echo "-----> Building Meteor app with ROOT_URL: $ROOT_URL"
 BUNDLE_DEST=`mktemp -d "$BUILDPACK_DIR/build-XXXX"`
 
 # The actual invocation of `meteor build`!

--- a/bin/compile
+++ b/bin/compile
@@ -180,7 +180,7 @@ echo "-----> Building Meteor app with ROOT_URL: $ROOT_URL"
 BUNDLE_DEST=`mktemp -d "$BUILDPACK_DIR/build-XXXX"`
 
 # The actual invocation of `meteor build`!
-HOME=$METEOR_DIR $METEOR build --server $ROOT_URL $SERVER_ONLY_FLAG --directory $BUNDLE_DEST
+HOME=$METEOR_DIR $METEOR build $BUILD_OPTIONS --server $ROOT_URL $SERVER_ONLY_FLAG --directory $BUNDLE_DEST
 
 echo "-----> Moving built slug to $COMPILE_DIR/app"
 mv $BUNDLE_DEST/bundle "$COMPILE_DIR/app"

--- a/bin/compile
+++ b/bin/compile
@@ -130,10 +130,36 @@ if [ -z "$SERVER_ONLY_FLAG" ]; then
   echo "-----> Moving on."
 fi
 
+# Identify the npm/node to use.  For Meteors > 1.3, we use `meteor npm` and
+# `meteor node` to find the bundled binaries.  For older releases, we need to
+# resort to using `find` to search out the appropriate version within the
+# bundle.
+set +e
+HOME=$METEOR_DIR $METEOR npm --version
+METEOR_NPM_EXIT_CODE=$?
+set -e
+if [ $METEOR_NPM_EXIT_CODE -eq 0 ]; then
+  # Newer meteor: it knows how to find its own npm/node.
+  METEOR_NPM="$METEOR npm"
+else
+  # Older meteor: search out npm/node within $METEOR_DIR.
+  BARE_VERSION=`cat $APP_RELEASE | sed -e 's/METEOR@//'`
+  METEOR_NPM=`find $METEOR_DIR -wholename "*$BARE_VERSION*/dev_bundle/bin/npm"`
+  METEOR_NODE=`find $METEOR_DIR -wholename "*$BARE_VERSION*/dev_bundle/bin/node"`
+  if [ -z "$METEOR_NPM" || -z "$METEOR_NODE" ] ; then
+    echo "FATAL: Can't find npm/node within meteor bundle. This is a bug. Please open an issue at https://github.com/AdmitHub/meteor-buildpack-horse.";
+    exit 1
+  fi
+  # Create link to node for use by bin/release, so it doesn't have to do a
+  # messy `find` with the release version. Use a hard link so that we can move
+  # $METEOR_DIR around without the link breaking.
+  ln $METEOR_NODE $METEOR_DIR/meteor-node
+fi
+
 # If we use npm on root, run npm install.  Don't use `--production` here, as we
 # may need devDependencies (e.g. webpack) in order to build the meteor app.
 if [ -e "$APP_SOURCE_DIR"/package.json ]; then
-  HOME=$METEOR_DIR $METEOR npm install
+  HOME=$METEOR_DIR $METEOR_NPM install
 fi
 
 # Related to https://github.com/meteor/meteor/issues/2796 and 
@@ -159,7 +185,7 @@ rmdir $BUNDLE_DEST
 # Run npm install on the built slug; only for `--production` dependencies.
 if [ -e "$COMPILE_DIR"/app/programs/server/package.json ]; then
   cd "$COMPILE_DIR"/app/programs/server
-  HOME=$METEOR_DIR $METEOR npm install --production
+  HOME=$METEOR_DIR $METEOR_NPM install --production
 fi
 
 # Move meteor installation to where we can use it in bin/release

--- a/bin/compile
+++ b/bin/compile
@@ -97,6 +97,7 @@ METEOR="$METEOR_DIR/.meteor/meteor" # The meteor binary.
 # Maybe update release. Upgrade only if needed because it's slow.
 CUR_RELEASE=`HOME=$METEOR_DIR $METEOR --version | sed -e 's/Meteor /METEOR@/'`
 APP_RELEASE=`cat "$APP_SOURCE_DIR/.meteor/release"`
+echo "-----> App targets $APP_RELEASE"
 if test "$CUR_RELEASE" != "$APP_RELEASE" ; then
   # Sort CUR_RELEASE and APP_RELEASE and find the oldest
   OLDER_RELEASE=`echo "$CUR_RELEASE\n$APP_RELEASE" | sort --version-sort | head -n1`

--- a/bin/compile
+++ b/bin/compile
@@ -137,14 +137,14 @@ if [ -z "$METEOR_NPM" ] || [ -z "$METEOR_NODE" ] ; then
   exit 1
 fi
 METEOR_NPM_BIN_DIR=`dirname -z "$METEOR_NPM"`
-METEOR_NPM_LIB_DIR=`dirname -z "$METEOR_NPM_BIN_DIR`/lib
+METEOR_NPM_NODE_MODULES_DIR="`dirname -z "$METEOR_NPM_BIN_DIR"`/lib/node_modules"
 
 # Copy npm/node into place.
 NPM="$COMPILE_DIR"/bin/npm
 NODE="$COMPILE_DIR"/bin/node
 cp "$METEOR_NPM" "$NPM"
 cp "$METEOR_NODE" "$NODE"
-cp -r "$METEOR_NPM_LIB_DIR/lib/node_modules" "$COMPILE_DIR/lib/"
+cp -r "$METEOR_NPM_NODE_MODULES_DIR" "$COMPILE_DIR/lib/"
 
 echo "-----> Using node: `$NODE --version`"
 echo "----->    and npm: `$NPM --version`"

--- a/bin/compile
+++ b/bin/compile
@@ -60,6 +60,7 @@ fi
 
 # Where we will install meteor. Has to be outside the APP_CHECKOUT_DIR.
 METEOR_DIR=`mktemp -d "$BUILDPACK_DIR"/meteor-XXXX`
+HOME=$METEOR_DIR
 # Where we'll put things we compile.
 COMPILE_DIR_SUFFIX=".meteor/heroku_build"
 COMPILE_DIR="$APP_CHECKOUT_DIR"/"$COMPILE_DIR_SUFFIX"
@@ -71,7 +72,7 @@ fi
 # Create directories as needed.
 mkdir -p "$APP_CHECKOUT_DIR" "$METEOR_DIR" "$COMPILE_DIR"
 
-# Update the path so we get npm, etc.
+# Update the path to include any binaries we need.
 PATH="$METEOR_DIR/.meteor:$COMPILE_DIR/bin:$PATH"
 
 # Set a default ROOT_URL if one is not defined. Currently, HEROKU_APP_NAME is
@@ -88,33 +89,21 @@ if [ -z "$ROOT_URL" ] ; then
 fi
 
 #
-# Install node
-#
-echo "-----> Installing node"
-NODE_VERSION=`curl -sS --get https://semver.io/node/resolve/0.10.x`
-NODE_URL="http://s3pository.heroku.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz"
-curl -sS $NODE_URL -o - | tar -zxf - -C $COMPILE_DIR --strip 1
-# Export some environment variables for npm to use when compiling stuff.
-export npm_config_prefix="$COMPILE_DIR"
-export CPATH="$COMPILE_DIR"/include
-export CPPPATH="$CPATH"
-
-#
 # Install meteor
 #
 echo "-----> Installing meteor"
-curl -sS https://install.meteor.com | HOME="$METEOR_DIR" /bin/sh
+curl -sS https://install.meteor.com | /bin/sh
 METEOR="$METEOR_DIR/.meteor/meteor" # The meteor binary.
 
 # Maybe update release. Upgrade only if needed because it's slow.
-CUR_RELEASE=`HOME=$METEOR_DIR $METEOR --version | sed -e 's/Meteor /METEOR@/'`
+CUR_RELEASE=`$METEOR --version | sed -e 's/Meteor /METEOR@/'`
 APP_RELEASE=`cat "$APP_SOURCE_DIR/.meteor/release"`
 if test "$CUR_RELEASE" != "$APP_RELEASE" ; then
   # Sort CUR_RELEASE and APP_RELEASE and find the oldest
   OLDER_RELEASE=`echo "$CUR_RELEASE\n$APP_RELEASE" | sort --version-sort | head -n1`
   if [ "$CUR_RELEASE" = "$OLDER_RELEASE" ]; then
     echo "-----> Upgrading meteor to $APP_RELEASE"
-    HOME=$METEOR_DIR $METEOR update --release $APP_RELEASE
+    $METEOR update --release $APP_RELEASE
   fi
 fi
 
@@ -127,7 +116,7 @@ cd $APP_SOURCE_DIR
 # Determine if we have --server-only flag capability. Allow non-zero return from grep.
 echo "-----> Checking if this meteor version supports --server-only"
 set +e
-HAS_SERVER_ONLY=`HOME=$METEOR_DIR $METEOR help build | grep -e '--server-only'`
+HAS_SERVER_ONLY=`$METEOR help build | grep -e '--server-only'`
 set -e
 if [ -n "$HAS_SERVER_ONLY" ] ; then
   SERVER_ONLY_FLAG='--server-only'
@@ -138,14 +127,14 @@ fi
 # platform gets ignored properly.
 if [ -z "$SERVER_ONLY_FLAG" ]; then
   echo "-----> Attempting to remove android platform."
-  HOME=$METEOR_DIR $METEOR remove-platform android || true
+  $METEOR remove-platform android || true
   echo "-----> Moving on."
 fi
 
 # If we use npm on root, run npm install.  Don't use `--production` here, as we
 # may need devDependencies (e.g. webpack) in order to build the meteor app.
 if [ -e "$APP_SOURCE_DIR"/package.json ]; then
-  npm install
+  $METEOR npm install
 fi
 
 # Related to https://github.com/meteor/meteor/issues/2796 and 
@@ -156,22 +145,22 @@ if [ -n "${BUILDPACK_PRELAUNCH_METEOR+1}" ]; then
   echo "-----> BUILDPACK_PRELAUNCH_METEOR: Pre-launching meteor to build packages assets"
   # Remove the Android platform because it fails due to the Android tools not
   # being installed, but leave the iOS platform because it's ignored.
-  HOME=$METEOR_DIR $METEOR remove-platform android || true
-  HOME=$METEOR_DIR timeout -s9 60 $METEOR --settings settings.json || true
+  $METEOR remove-platform android || true
+  timeout -s9 60 $METEOR --settings settings.json || true
 fi
 
 # Now on to bundling. Don't put the bundle in $APP_CHECKOUT_DIR, or it will
 # recurse, trying to bundle up its own bundling.
 BUNDLE_DEST=`mktemp -d "$BUILDPACK_DIR/build-XXXX"`
 echo "-----> Building Meteor with ROOT_URL: $ROOT_URL"
-HOME=$METEOR_DIR $METEOR build --server $ROOT_URL $SERVER_ONLY_FLAG --directory $BUNDLE_DEST
+$METEOR build --server $ROOT_URL $SERVER_ONLY_FLAG --directory $BUNDLE_DEST
 mv $BUNDLE_DEST/bundle "$COMPILE_DIR/app"
 rmdir $BUNDLE_DEST
 
 # Run npm install on the built slug; only for `--production` dependencies.
 if [ -e "$COMPILE_DIR"/app/programs/server/package.json ]; then
   cd "$COMPILE_DIR"/app/programs/server
-  npm install --production
+  $METEOR npm install --production
 fi
 
 #

--- a/bin/compile
+++ b/bin/compile
@@ -140,6 +140,7 @@ fi
 # Copy node into place for production.
 NODE="$COMPILE_DIR"/bin/node
 cp "$METEOR_NODE" "$NODE"
+chmod a+x "$NODE"
 
 echo "-----> Using node: `$NODE --version`"
 echo "----->    and npm: `$METEOR_NPM --version`"

--- a/bin/compile
+++ b/bin/compile
@@ -136,23 +136,18 @@ if [ -z "$METEOR_NPM" ] || [ -z "$METEOR_NODE" ] ; then
   echo "FATAL: Can't find npm/node within meteor bundle. This is a bug. Please open an issue at https://github.com/AdmitHub/meteor-buildpack-horse.";
   exit 1
 fi
-METEOR_NPM_BIN_DIR=`dirname -z "$METEOR_NPM"`
-METEOR_NPM_NODE_MODULES_DIR="`dirname -z "$METEOR_NPM_BIN_DIR"`/lib/node_modules"
 
-# Copy npm/node into place.
-NPM="$COMPILE_DIR"/bin/npm
+# Copy node into place for production.
 NODE="$COMPILE_DIR"/bin/node
-cp "$METEOR_NPM" "$NPM"
 cp "$METEOR_NODE" "$NODE"
-cp -r "$METEOR_NPM_NODE_MODULES_DIR" "$COMPILE_DIR/lib/"
 
 echo "-----> Using node: `$NODE --version`"
-echo "----->    and npm: `$NPM --version`"
+echo "----->    and npm: `$METEOR_NPM --version`"
 
 # If we use npm on root, run npm install.  Don't use `--production` here, as we
 # may need devDependencies (e.g. webpack) in order to build the meteor app.
 if [ -e "$APP_SOURCE_DIR"/package.json ]; then
-  HOME=$METEOR_DIR $NPM install
+  HOME=$METEOR_DIR $METEOR_NPM install
 fi
 
 # Related to https://github.com/meteor/meteor/issues/2796 and 
@@ -184,7 +179,7 @@ rmdir $BUNDLE_DEST
 echo "-----> Installing npm production dependencies on built slug"
 if [ -e "$COMPILE_DIR"/app/programs/server/package.json ]; then
   cd "$COMPILE_DIR"/app/programs/server
-  HOME=$METEOR_DIR $NPM install --production
+  HOME=$METEOR_DIR $METEOR_NPM install --production
   cd "$APP_SOURCE_DIR"
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -71,7 +71,7 @@ fi
 # Create directories as needed.
 mkdir -p "$APP_CHECKOUT_DIR" "$METEOR_DIR" "$COMPILE_DIR"
 
-# Update the path to include any binaries we need.
+# Update the path a place to store our compiled app/binaries
 PATH="$METEOR_DIR/.meteor:$COMPILE_DIR/bin:$PATH"
 
 # Set a default ROOT_URL if one is not defined. Currently, HEROKU_APP_NAME is
@@ -162,7 +162,7 @@ if [ -e "$COMPILE_DIR"/app/programs/server/package.json ]; then
   HOME=$METEOR_DIR $METEOR npm install --production
 fi
 
-# Move meteor installation to where we can use it.
+# Move meteor installation to where we can use it in bin/release
 mv "$METEOR_DIR" "$APP_CHECKOUT_DIR/meteor-dist"
 
 #
@@ -173,7 +173,7 @@ echo "-----> Adding PATH environment"
 mkdir -p "$APP_CHECKOUT_DIR"/.profile.d
 cat > "$APP_CHECKOUT_DIR"/.profile.d/path.sh <<EOF
   #!/bin/sh
-  export PATH=$METEOR_DIR/.meteor:\$HOME/$COMPILE_DIR_SUFFIX/bin:\$PATH
+  export PATH=\$HOME/$COMPILE_DIR_SUFFIX/bin:\$PATH
   export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:\$HOME/$COMPILE_DIR_SUFFIX/lib
 EOF
 

--- a/bin/compile
+++ b/bin/compile
@@ -171,7 +171,8 @@ echo "-----> Adding PATH environment"
 mkdir -p "$APP_CHECKOUT_DIR"/.profile.d
 cat > "$APP_CHECKOUT_DIR"/.profile.d/path.sh <<EOF
   #!/bin/sh
-  export PATH=\$METEOR_DIR/.meteor:\$HOME/$COMPILE_DIR_SUFFIX/bin:\$PATH
+  export HOME=$HOME
+  export PATH=$METEOR_DIR/.meteor:\$HOME/$COMPILE_DIR_SUFFIX/bin:\$PATH
   export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:\$HOME/$COMPILE_DIR_SUFFIX/lib
 EOF
 

--- a/bin/compile
+++ b/bin/compile
@@ -31,10 +31,16 @@ if [ -n "${BUILDPACK_VERBOSE+1}" ]; then
   set -x
 fi
 
+
 # Get the path to dir one above this file.
 BUILDPACK_DIR=$(cd -P -- "$(dirname -- "$0")" && cd .. && pwd -P)
 # Get the directory our app is checked out in (the "BUILD_DIR"), passed by Heroku
 APP_CHECKOUT_DIR=$1
+CACHE_DIR=$2
+if [ -n "${BUILDPACK_CLEAR_CACHE+1}" ]; then
+  echo "----> Clearing cache dir."
+  rm -rf "$CACHE_DIR"
+fi
 
 #
 # Find the meteor app ($APP_SOURCE_DIR).
@@ -58,8 +64,10 @@ if [ ! -d "$APP_SOURCE_DIR/.meteor" ]; then
   exit 1
 fi
 
+APP_RELEASE=`cat "$APP_SOURCE_DIR/.meteor/release" | sed -e 's/METEOR@//'`
+
 # Where we will install meteor. Has to be outside the APP_CHECKOUT_DIR.
-METEOR_DIR=`mktemp -d "$BUILDPACK_DIR"/meteor-XXXX`
+METEOR_DIR="$CACHE_DIR/$APP_RELEASE"
 # Where we'll put things we compile.
 COMPILE_DIR_SUFFIX=".meteor/heroku_build"
 COMPILE_DIR="$APP_CHECKOUT_DIR"/"$COMPILE_DIR_SUFFIX"
@@ -71,9 +79,6 @@ fi
 # Create directories as needed.
 mkdir -p "$APP_CHECKOUT_DIR" "$METEOR_DIR"
 mkdir -p "$COMPILE_DIR" "$COMPILE_DIR/bin" "$COMPILE_DIR/lib"
-
-# Update the path a place to store our compiled app/binaries
-PATH="$METEOR_DIR/.meteor:$COMPILE_DIR/bin:$PATH"
 
 # Set a default ROOT_URL if one is not defined. Currently, HEROKU_APP_NAME is
 # only available if you enable the labs addon "Heroku Dyno Metadata":
@@ -91,9 +96,11 @@ fi
 #
 # Install meteor
 #
-echo "-----> Installing meteor"
-APP_RELEASE=`cat "$APP_SOURCE_DIR/.meteor/release" | sed -e 's/METEOR@//'`
-curl -sS "https://install.meteor.com/?release=$APP_RELEASE" | HOME="$METEOR_DIR" /bin/sh
+
+if [ ! -e "$METEOR_DIR/.meteor/meteor" ]; then
+  echo "-----> Installing meteor"
+  curl -sS "https://install.meteor.com/?release=$APP_RELEASE" | HOME="$METEOR_DIR" /bin/sh
+fi
 METEOR="$METEOR_DIR/.meteor/meteor" # The meteor binary.
 
 echo "-----> Meteor version: `HOME=$METEOR_DIR $METEOR --version`"
@@ -136,13 +143,14 @@ if [ -z "$METEOR_NPM" ] || [ -z "$METEOR_NODE" ] ; then
   echo "FATAL: Can't find npm/node within meteor bundle. This is a bug. Please open an issue at https://github.com/AdmitHub/meteor-buildpack-horse.";
   exit 1
 fi
-# Add npm to path so that 1.4's npm-rebuild.js will function.
-PATH="$PATH:`dirname $METEOR_NPM`"
 
 # Copy node into place for production.
 NODE="$COMPILE_DIR"/bin/node
 cp "$METEOR_NODE" "$NODE"
 chmod a+x "$NODE"
+
+# Add npm and node path so that 1.4's npm-rebuild.js will function.
+PATH="$METEOR_DIR/.meteor:`dirname $METEOR_NPM`:$COMPILE_DIR/bin:$PATH"
 
 echo "-----> Using node: `$NODE --version`"
 echo "----->    and npm: `$METEOR_NPM --version`"

--- a/bin/compile
+++ b/bin/compile
@@ -69,7 +69,8 @@ if [ -z "$BUILDPACK_VERBOSE" ]; then
 fi
 
 # Create directories as needed.
-mkdir -p "$APP_CHECKOUT_DIR" "$METEOR_DIR" "$COMPILE_DIR" "$COMPILE_DIR/bin"
+mkdir -p "$APP_CHECKOUT_DIR" "$METEOR_DIR"
+mkdir -p "$COMPILE_DIR" "$COMPILE_DIR/bin" "$COMPILE_DIR/lib"
 
 # Update the path a place to store our compiled app/binaries
 PATH="$METEOR_DIR/.meteor:$COMPILE_DIR/bin:$PATH"
@@ -135,12 +136,15 @@ if [ -z "$METEOR_NPM" ] || [ -z "$METEOR_NODE" ] ; then
   echo "FATAL: Can't find npm/node within meteor bundle. This is a bug. Please open an issue at https://github.com/AdmitHub/meteor-buildpack-horse.";
   exit 1
 fi
+METEOR_NPM_BIN_DIR=`dirname -z "$METEOR_NPM"`
+METEOR_NPM_LIB_DIR=`dirname -z "$METEOR_NPM_BIN_DIR`/lib
 
 # Copy npm/node into place.
 NPM="$COMPILE_DIR"/bin/npm
 NODE="$COMPILE_DIR"/bin/node
 cp "$METEOR_NPM" "$NPM"
 cp "$METEOR_NODE" "$NODE"
+cp -r "$METEOR_NPM_LIB_DIR/lib/node_modules" "$COMPILE_DIR/lib/"
 
 echo "-----> Using node: `$NODE --version`"
 echo "----->    and npm: `$NPM --version`"

--- a/bin/compile
+++ b/bin/compile
@@ -133,7 +133,7 @@ METEOR_NODE=`find $METEOR_DIR -wholename "*$APP_RELEASE*/dev_bundle/bin/node"`
 METEOR_NPM=`echo "$METEOR_NPM" | sed -e 's/[[:space:]]*$//'`
 METEOR_NODE=`echo "$METEOR_NODE" | sed -e 's/[[:space:]]*$//'`
 if [ -z "$METEOR_NPM" ] || [ -z "$METEOR_NODE" ] ; then
-  ls -R "$METEOR_DIR"
+  ls -Ra "$METEOR_DIR"
   echo "FATAL: Can't find npm/node within meteor bundle. This is a bug. Please open an issue at https://github.com/AdmitHub/meteor-buildpack-horse.";
   exit 1
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -171,7 +171,7 @@ echo "-----> Adding PATH environment"
 mkdir -p "$APP_CHECKOUT_DIR"/.profile.d
 cat > "$APP_CHECKOUT_DIR"/.profile.d/path.sh <<EOF
   #!/bin/sh
-  export PATH=\$HOME/$COMPILE_DIR_SUFFIX/bin:\$PATH
+  export PATH=\$METEOR_DIR/.meteor:\$HOME/$COMPILE_DIR_SUFFIX/bin:\$PATH
   export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:\$HOME/$COMPILE_DIR_SUFFIX/lib
 EOF
 

--- a/bin/compile
+++ b/bin/compile
@@ -133,7 +133,6 @@ METEOR_NODE=`find $METEOR_DIR -wholename "*/dev_bundle/bin/node"`
 METEOR_NPM=`echo "$METEOR_NPM" | sed -e 's/[[:space:]]*$//'`
 METEOR_NODE=`echo "$METEOR_NODE" | sed -e 's/[[:space:]]*$//'`
 if [ -z "$METEOR_NPM" ] || [ -z "$METEOR_NODE" ] ; then
-  ls -Ra "$METEOR_DIR"
   echo "FATAL: Can't find npm/node within meteor bundle. This is a bug. Please open an issue at https://github.com/AdmitHub/meteor-buildpack-horse.";
   exit 1
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -91,27 +91,16 @@ fi
 # Install meteor
 #
 echo "-----> Installing meteor"
-curl -sS https://install.meteor.com | HOME="$METEOR_DIR" /bin/sh
+APP_RELEASE=`cat "$APP_SOURCE_DIR/.meteor/release"` | sed -e 's/METEOR@//'
+curl -sS "https://install.meteor.com/?release=$APP_RELEASE" | HOME="$METEOR_DIR" /bin/sh
 METEOR="$METEOR_DIR/.meteor/meteor" # The meteor binary.
 
-# Maybe update release. Upgrade only if needed because it's slow.
-CUR_RELEASE=`HOME=$METEOR_DIR $METEOR --version | sed -e 's/Meteor /METEOR@/'`
-APP_RELEASE=`cat "$APP_SOURCE_DIR/.meteor/release"`
-echo "-----> App targets $APP_RELEASE"
-if test "$CUR_RELEASE" != "$APP_RELEASE" ; then
-  # Sort CUR_RELEASE and APP_RELEASE and find the oldest
-  OLDER_RELEASE=`echo "$CUR_RELEASE\n$APP_RELEASE" | sort --version-sort | head -n1`
-  if [ "$CUR_RELEASE" = "$OLDER_RELEASE" ]; then
-    echo "-----> Upgrading meteor to $APP_RELEASE"
-    HOME=$METEOR_DIR $METEOR update --release $APP_RELEASE
-  fi
-fi
+echo "-----> Meteor version: `HOME=$METEOR_DIR $METEOR --version`"
 
 #
 # Build the meteor app!
 #
-echo "-----> Bundling bundle"
-cd $APP_SOURCE_DIR
+cd "$APP_SOURCE_DIR"
 
 # Determine if we have --server-only flag capability. Allow non-zero return from grep.
 echo "-----> Checking if this meteor version supports --server-only"
@@ -131,38 +120,35 @@ if [ -z "$SERVER_ONLY_FLAG" ]; then
   echo "-----> Moving on."
 fi
 
-# Identify the npm/node to use.  For Meteors > 1.3, we use `meteor npm` and
-# `meteor node` to find the bundled binaries.  For older releases, we need to
-# resort to using `find` to search out the appropriate version within the
-# bundle.
-set +e
-HOME=$METEOR_DIR $METEOR npm --version
-METEOR_NPM_EXIT_CODE=$?
-set -e
-if [ $METEOR_NPM_EXIT_CODE -eq 0 ]; then
-  # Newer meteor: it knows how to find its own npm/node.
-  METEOR_NPM="$METEOR npm"
-  echo "-----> Using 'meteor node', with version: `HOME=$METEOR_DIR $METEOR node --version`"
-else
-  # Older meteor: search out npm/node within $METEOR_DIR.
-  BARE_VERSION=`cat $APP_RELEASE | sed -e 's/METEOR@//'`
-  METEOR_NPM=`find $METEOR_DIR -wholename "*$BARE_VERSION*/dev_bundle/bin/npm"`
-  METEOR_NODE=`find $METEOR_DIR -wholename "*$BARE_VERSION*/dev_bundle/bin/node"`
-  if [ -z "$METEOR_NPM" || -z "$METEOR_NODE" ] ; then
-    echo "FATAL: Can't find npm/node within meteor bundle. This is a bug. Please open an issue at https://github.com/AdmitHub/meteor-buildpack-horse.";
-    exit 1
-  fi
-  # Create link to node for use by bin/release, so it doesn't have to do a
-  # messy `find` with the release version. Use a hard link so that we can move
-  # $METEOR_DIR around without the link breaking.
-  ln $METEOR_NODE $METEOR_DIR/meteor-node
-  echo "-----> Using searched-for node: `$METEOR_DIR/meteor-node --version`"
+# Identify the npm/node to use. While we could use `meteor node` and `meteor
+# npm` to execute these directly, to use them in prod, we'd need to copy the
+# meteor world into the built slug, and that's too large (Issue #125).
+# Instead, search for the binaries within meteor, and copy them into our built
+# slug.
+
+METEOR_NPM=`find $METEOR_DIR -wholename "*$APP_RELEASE*/dev_bundle/bin/npm"`
+METEOR_NODE=`find $METEOR_DIR -wholename "*$APP_RELEASE*/dev_bundle/bin/node"`
+# Trim whitespace
+METEOR_NPM=`echo "$METEOR_NPM" | sed -e 's/[[:space:]]*$//'`
+METEOR_NODE=`echo "$METEOR_NODE" | sed -e 's/[[:space:]]*$//'`
+if [ -z "$METEOR_NPM" ] || [ -z "$METEOR_NODE" ] ; then
+  echo "FATAL: Can't find npm/node within meteor bundle. This is a bug. Please open an issue at https://github.com/AdmitHub/meteor-buildpack-horse.";
+  exit 1
 fi
+
+# Copy npm/node into place.
+NPM="$COMPILE_DIR"/bin/npm
+NODE="$COMPILE_DIR"/bin/node
+cp "$METEOR_NPM" "$NPM"
+cp "$METEOR_NODE" "$NODE"
+
+echo "-----> Using node: `$NODE --version`"
+echo "----->    and npm: `$NPM --version`"
 
 # If we use npm on root, run npm install.  Don't use `--production` here, as we
 # may need devDependencies (e.g. webpack) in order to build the meteor app.
 if [ -e "$APP_SOURCE_DIR"/package.json ]; then
-  HOME=$METEOR_DIR $METEOR_NPM install
+  HOME=$METEOR_DIR $NPM install
 fi
 
 # Related to https://github.com/meteor/meteor/issues/2796 and 
@@ -177,22 +163,26 @@ if [ -n "${BUILDPACK_PRELAUNCH_METEOR+1}" ]; then
   HOME=$METEOR_DIR timeout -s9 60 $METEOR --settings settings.json || true
 fi
 
-# Now on to bundling. Don't put the bundle in $APP_CHECKOUT_DIR, or it will
-# recurse, trying to bundle up its own bundling.
-BUNDLE_DEST=`mktemp -d "$BUILDPACK_DIR/build-XXXX"`
+# Now on to bundling. Don't put the bundle in $APP_CHECKOUT_DIR during
+# bundling, or it will recurse, trying to bundle up its own bundling.
+
 echo "-----> Building Meteor with ROOT_URL: $ROOT_URL"
+BUNDLE_DEST=`mktemp -d "$BUILDPACK_DIR/build-XXXX"`
+
+# The actual invocation of `meteor build`!
 HOME=$METEOR_DIR $METEOR build --server $ROOT_URL $SERVER_ONLY_FLAG --directory $BUNDLE_DEST
+
+echo "-----> Moving built slug to $COMPILE_DIR/app"
 mv $BUNDLE_DEST/bundle "$COMPILE_DIR/app"
 rmdir $BUNDLE_DEST
 
 # Run npm install on the built slug; only for `--production` dependencies.
+echo "-----> Installing npm production dependencies on built slug"
 if [ -e "$COMPILE_DIR"/app/programs/server/package.json ]; then
   cd "$COMPILE_DIR"/app/programs/server
-  HOME=$METEOR_DIR $METEOR_NPM install --production
+  HOME=$METEOR_DIR $NPM install --production
+  cd "$APP_SOURCE_DIR"
 fi
-
-# Move meteor installation to where we can use it in bin/release
-mv "$METEOR_DIR" "$APP_CHECKOUT_DIR/meteor-dist"
 
 #
 # Environment

--- a/bin/compile
+++ b/bin/compile
@@ -148,7 +148,7 @@ echo "----->    and npm: `$METEOR_NPM --version`"
 # If we use npm on root, run npm install.  Don't use `--production` here, as we
 # may need devDependencies (e.g. webpack) in order to build the meteor app.
 if [ -e "$APP_SOURCE_DIR"/package.json ]; then
-  HOME=$METEOR_DIR $METEOR_NPM install
+  $METEOR_NPM install
 fi
 
 # Related to https://github.com/meteor/meteor/issues/2796 and 
@@ -180,7 +180,7 @@ rmdir $BUNDLE_DEST
 echo "-----> Installing npm production dependencies on built slug"
 if [ -e "$COMPILE_DIR"/app/programs/server/package.json ]; then
   cd "$COMPILE_DIR"/app/programs/server
-  HOME=$METEOR_DIR $METEOR_NPM install --production
+  $METEOR_NPM install --production
   cd "$APP_SOURCE_DIR"
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -142,6 +142,7 @@ set -e
 if [ $METEOR_NPM_EXIT_CODE -eq 0 ]; then
   # Newer meteor: it knows how to find its own npm/node.
   METEOR_NPM="$METEOR npm"
+  echo "-----> Using 'meteor node', with version: `HOME=$METEOR_DIR $METEOR node --version`"
 else
   # Older meteor: search out npm/node within $METEOR_DIR.
   BARE_VERSION=`cat $APP_RELEASE | sed -e 's/METEOR@//'`
@@ -155,6 +156,7 @@ else
   # messy `find` with the release version. Use a hard link so that we can move
   # $METEOR_DIR around without the link breaking.
   ln $METEOR_NODE $METEOR_DIR/meteor-node
+  echo "-----> Using searched-for node: `$METEOR_DIR/meteor-node --version`"
 fi
 
 # If we use npm on root, run npm install.  Don't use `--production` here, as we

--- a/bin/compile
+++ b/bin/compile
@@ -136,6 +136,8 @@ if [ -z "$METEOR_NPM" ] || [ -z "$METEOR_NODE" ] ; then
   echo "FATAL: Can't find npm/node within meteor bundle. This is a bug. Please open an issue at https://github.com/AdmitHub/meteor-buildpack-horse.";
   exit 1
 fi
+# Add npm to path so that 1.4's npm-rebuild.js will function.
+PATH="$PATH:`dirname $METEOR_NPM`"
 
 # Copy node into place for production.
 NODE="$COMPILE_DIR"/bin/node

--- a/bin/release
+++ b/bin/release
@@ -4,5 +4,5 @@ cat <<EOF
 addons:
   - mongolab
 default_process_types:
-  web: HOME=.meteor/heroku_build/bin/node .meteor/heroku_build/app/main.js
+  web: .meteor/heroku_build/bin/node .meteor/heroku_build/app/main.js
 EOF

--- a/bin/release
+++ b/bin/release
@@ -4,5 +4,5 @@ cat <<EOF
 addons:
   - mongolab
 default_process_types:
-  web: HOME=.meteor-dist ./meteor-dist/.meteor/meteor node .meteor/heroku_build/app/main.js || HOME=.meteor-dist .meteor-dist/meteor-node .meteor/heroku_build/app/main.js
+  web: HOME=.meteor/heroku_build/bin/node .meteor/hoerku_build/app/main.js
 EOF

--- a/bin/release
+++ b/bin/release
@@ -4,5 +4,5 @@ cat <<EOF
 addons:
   - mongolab
 default_process_types:
-  web: .meteor/heroku_build/bin/node .meteor/heroku_build/app/main.js
+  web: meteor node .meteor/heroku_build/app/main.js
 EOF

--- a/bin/release
+++ b/bin/release
@@ -4,5 +4,5 @@ cat <<EOF
 addons:
   - mongolab
 default_process_types:
-  web: HOME=.meteor/heroku_build/bin/node .meteor/hoerku_build/app/main.js
+  web: HOME=.meteor/heroku_build/bin/node .meteor/heroku_build/app/main.js
 EOF

--- a/bin/release
+++ b/bin/release
@@ -4,5 +4,5 @@ cat <<EOF
 addons:
   - mongolab
 default_process_types:
-  web: HOME=.meteor-dist ./meteor-dist/.meteor/meteor node .meteor/heroku_build/app/main.js
+  web: HOME=.meteor-dist ./meteor-dist/.meteor/meteor node .meteor/heroku_build/app/main.js || HOME=.meteor-dist .meteor-dist/meteor-node .meteor/heroku_build/app/main.js
 EOF

--- a/bin/release
+++ b/bin/release
@@ -4,5 +4,5 @@ cat <<EOF
 addons:
   - mongolab
 default_process_types:
-  web: meteor node .meteor/heroku_build/app/main.js
+  web: HOME=.meteor-dist ./meteor-dist/.meteor/meteor node .meteor/heroku_build/app/main.js
 EOF


### PR DESCRIPTION
Major refactor in the way that `node` and `npm` are handled by the buildpack.  Rather than installing our own nodejs version (pinned to 0.10.x), use the version that is distributed with Meteor.  Locate and copy that nodejs binary onto the built slug on production to retain small slug sizes without dragging in the whole meteor world.  Addresses #120 and #125.

Rather than installing the latest Meteor release and then "upgrading" (or letting Meteor downgrade on first-run), use `https://install.meteor.com/?release=$APP_RELEASE` to install the correct version from the beginning.  This helps toward #64.  (Thanks @tab00).

Install Meteor on the Heroku $CACHE_DIR so that the version can be retained between builds.  This helps further with #64.