### PR TITLE
Ability to set additional node parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The following are some important environment variables for bundling and running 
  - `BUILDPACK_VERBOSE`: Set `BUILDPACK_VERBOSE=1` to enable verbose bash debugging during slug compilation. Only takes effect after the environment variables have been loaded.
  - `BUILDPACK_CLEAR_CACHE`: This buildpack stores the meteor installation in the [CACHE_DIR](https://devcenter.heroku.com/articles/buildpack-api#caching) to speed up subsequent builds. Set `BUILDPACK_CLEAR_CACHE=1` to clear this cache on startup.
  - `BUILD_OPTIONS`: Set to any additional options you'd like to add to the invocation of `meteor build`, for example `--debug` or `--allow-incompatible-update`.
+ - `NODEJS_PARAMS`: additional parameters for running `node` binary. This can be used eg. for [adjusting garbage collector settings](https://devcenter.heroku.com/articles/node-best-practices#avoid-garbage) by putting `--optimize_for_size --max_old_space_size=460 --gc_interval=100` here
 
 ## Extras
 

--- a/bin/release
+++ b/bin/release
@@ -4,5 +4,5 @@ cat <<EOF
 addons:
   - mongolab
 default_process_types:
-  web: .meteor/heroku_build/bin/node .meteor/heroku_build/app/main.js
+  web: .meteor/heroku_build/bin/node $NODEJS_PARAMS .meteor/heroku_build/app/main.js
 EOF

--- a/bin/release
+++ b/bin/release
@@ -4,5 +4,5 @@ cat <<EOF
 addons:
   - mongolab
 default_process_types:
-  web: .meteor/heroku_build/bin/node $NODEJS_PARAMS .meteor/heroku_build/app/main.js
+  web: .meteor/heroku_build/bin/node \$NODEJS_PARAMS .meteor/heroku_build/app/main.js
 EOF


### PR DESCRIPTION
Added ability to inject additional parameters for `node` binary.

This pull request is followup of my problems with running Meteor on Heroku dyno with 500MB of RAM and exceeding RAM quota. I found [this](https://devcenter.heroku.com/articles/node-best-practices#avoid-garbage) description how to solve this issue but wasn't able to use it without changes from this pull request.
