### PR TITLE
Force install of devDependencies

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -171,7 +171,7 @@ echo "----->    and npm: `$METEOR_NPM --version`"
 # If we use npm on root, run npm install.  Don't use `--production` here, as we
 # may need devDependencies (e.g. webpack) in order to build the meteor app.
 if [ -e "$APP_SOURCE_DIR"/package.json ]; then
-  $METEOR_NPM install
+  NODE_ENV=development $METEOR_NPM install
 fi
 
 # Related to https://github.com/meteor/meteor/issues/2796 and


### PR DESCRIPTION
The idea of the buildpack is to install `devDependencies` even if the `NODE_ENV` is set to `production` simply avoiding the flag `--production` on `npm install`.

Unfortunately this doesn't work since npm never installs `devDependencies` if the environment is set to `production`.  Official documentation states: 

> With the --production flag (or when the NODE_ENV environment variable is set to production), npm will not install modules listed in devDependencies. ([link](https://docs.npmjs.com/cli/install))

To fix that we can run npm install as `development`.