### PR TITLE
Use yarn instead of npm

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -152,10 +152,6 @@ METEOR_NODE=`METEOR node -e "process.stdout.write(process.execPath)"`
 # Assume npm is in the same dir as node.
 METEOR_NPM="`dirname "$METEOR_NODE"`/npm"
 
-# install yarn
-touch $HOME/.bashrc
-curl -o- -L https://yarnpkg.com/install.sh | bash
-
 if [ -z "$METEOR_NPM" ] || [ -z "$METEOR_NODE" ] ; then
   echo "FATAL: Can't find npm/node within meteor bundle. This is a bug. Please open an issue at https://github.com/AdmitHub/meteor-buildpack-horse.";
   exit 1
@@ -168,6 +164,11 @@ chmod a+x "$NODE"
 
 # Add npm and node path so that 1.4's npm-rebuild.js will function.
 PATH="$METEOR_DIR/.meteor:`dirname $METEOR_NPM`:$COMPILE_DIR/bin:$PATH"
+
+# install yarn
+touch $HOME/.bashrc
+echo 'export PATH="$HOME/.yarn/bin:$PATH"' >> $HOME/.bashrc
+curl -o- -L https://yarnpkg.com/install.sh | bash
 
 echo "-----> Using node: `$NODE --version`"
 echo "----->    and npm: `$METEOR_NPM --version`"

--- a/bin/compile
+++ b/bin/compile
@@ -167,8 +167,8 @@ PATH="$METEOR_DIR/.meteor:`dirname $METEOR_NPM`:$COMPILE_DIR/bin:$PATH"
 
 # install yarn
 touch $HOME/.bashrc
-echo 'export PATH="$HOME/.yarn/bin:$PATH"' >> $HOME/.bashrc
 curl -o- -L https://yarnpkg.com/install.sh | bash
+export PATH="$HOME/.yarn/bin:$PATH"
 
 echo "-----> Using node: `$NODE --version`"
 echo "----->    and npm: `$METEOR_NPM --version`"

--- a/bin/compile
+++ b/bin/compile
@@ -152,6 +152,10 @@ METEOR_NODE=`METEOR node -e "process.stdout.write(process.execPath)"`
 # Assume npm is in the same dir as node.
 METEOR_NPM="`dirname "$METEOR_NODE"`/npm"
 
+# install yarn
+touch $HOME/.bashrc
+curl -o- -L https://yarnpkg.com/install.sh | bash
+
 if [ -z "$METEOR_NPM" ] || [ -z "$METEOR_NODE" ] ; then
   echo "FATAL: Can't find npm/node within meteor bundle. This is a bug. Please open an issue at https://github.com/AdmitHub/meteor-buildpack-horse.";
   exit 1
@@ -167,11 +171,12 @@ PATH="$METEOR_DIR/.meteor:`dirname $METEOR_NPM`:$COMPILE_DIR/bin:$PATH"
 
 echo "-----> Using node: `$NODE --version`"
 echo "----->    and npm: `$METEOR_NPM --version`"
+echo "----->    and yarn: `yarn --version`"
 
 # If we use npm on root, run npm install.  Don't use `--production` here, as we
 # may need devDependencies (e.g. webpack) in order to build the meteor app.
 if [ -e "$APP_SOURCE_DIR"/package.json ]; then
-  $METEOR_NPM install
+  yarn install
 fi
 
 # Related to https://github.com/meteor/meteor/issues/2796 and
@@ -203,7 +208,7 @@ rmdir $BUNDLE_DEST
 echo "-----> Installing npm production dependencies on built slug"
 if [ -e "$COMPILE_DIR"/app/programs/server/package.json ]; then
   cd "$COMPILE_DIR"/app/programs/server
-  $METEOR_NPM install --production
+  yarn install --production
   cd "$APP_SOURCE_DIR"
 fi
 


### PR DESCRIPTION
This uses yarn instead of npm for application installation. At [OK GROW!](https://github.com/okgrow/meteor-buildpack-horse), we are changing our process to pretty much use yarn everywhere, we wanted our buildpack to reflect that as well.

For your consideration 😊  Thanks 🤘