### PR TITLE
Cache node modules and meteor build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -171,7 +171,14 @@ echo "----->    and npm: `$METEOR_NPM --version`"
 # If we use npm on root, run npm install.  Don't use `--production` here, as we
 # may need devDependencies (e.g. webpack) in order to build the meteor app.
 if [ -e "$APP_SOURCE_DIR"/package.json ]; then
+  mkdir -p "$CACHE_DIR/meteor-dev-modules"
+  if [ -n "$(ls -A $CACHE_DIR/meteor-dev-modules)" ]; then
+    echo "-----> Reusing development node_modules cache"
+    mkdir -p "$APP_SOURCE_DIR/node_modules"
+    mv "$CACHE_DIR/meteor-dev-modules/*" "$APP_SOURCE_DIR/node_modules"
+  fi
   $METEOR_NPM install
+  cp -a "$APP_SOURCE_DIR/node_modules/*" "$CACHE_DIR/meteor-dev-modules/"
 fi
 
 # Related to https://github.com/meteor/meteor/issues/2796 and
@@ -193,6 +200,12 @@ echo "-----> Building Meteor app with ROOT_URL: $ROOT_URL"
 BUNDLE_DEST=`mktemp -d "$BUILDPACK_DIR/build-XXXX"`
 
 # The actual invocation of `meteor build`!
+mkdir -p "$CACHE_DIR/meteor-build"
+rm -rf "$APP_SOURCE_DIR"/.meteor/local
+if [ -n "$(ls -A $CACHE_DIR/meteor-build)" ]; then
+  echo "-----> Reusing meteor build cache"
+fi
+ln -s "$CACHE_DIR/meteor-build" "$APP_SOURCE_DIR/.meteor/local"
 METEOR build $BUILD_OPTIONS --server $ROOT_URL $SERVER_ONLY_FLAG --directory $BUNDLE_DEST
 
 echo "-----> Moving built slug to $COMPILE_DIR/app"
@@ -203,7 +216,14 @@ rmdir $BUNDLE_DEST
 echo "-----> Installing npm production dependencies on built slug"
 if [ -e "$COMPILE_DIR"/app/programs/server/package.json ]; then
   cd "$COMPILE_DIR"/app/programs/server
+  mkdir -p "$CACHE_DIR/meteor-prod-modules"
+  if [ -n "$(ls -A $CACHE_DIR/meteor-prod-modules)" ]; then
+    echo "-----> Reusing production node_modules cache"
+  fi
+  mv "$CACHE_DIR/meteor-prod-modules/*" "$COMPILE_DIR/app/programs/server/node_modules" &> /dev/null || true
+  rm -rf "$CACHE_DIR/meteor-prod-modules"
   $METEOR_NPM install --production
+  cp -R "$COMPILE_DIR/app/programs/server/node_modules" "$CACHE_DIR/meteor-prod-modules"
   cd "$APP_SOURCE_DIR"
 fi
 
@@ -235,5 +255,5 @@ done
 #
 if [ -n "${BUILDPACK_CLEAR_CACHE+1}" ]; then
   echo "-----> Clearing cache dir."
-  rm -rf $METEOR_DIR
+  rm -rf "$CACHE_DIR/*"
 fi


### PR DESCRIPTION
I've added caching for development and production `node_modules`. I'm also saving the cache, meteor generates during the build.
Reusing that cache, reduced my build time from ~30 minutes to ~10 minutes (!)